### PR TITLE
Handle no response scenario when there is an error

### DIFF
--- a/Runtime/Android/GoogleUserMessagingPlatform.java
+++ b/Runtime/Android/GoogleUserMessagingPlatform.java
@@ -155,6 +155,7 @@ public class GoogleUserMessagingPlatform
             {
                 // Handle the error.
                 logError("onConsentInfoUpdateFailure ERROR: "+formError.getMessage());
+                LoadForm( false, true );
             }
         );
     }

--- a/Runtime/iOS/GoogleUserMessagingPlatform.mm
+++ b/Runtime/iOS/GoogleUserMessagingPlatform.mm
@@ -320,9 +320,8 @@ extern "C"
                     {
                         Log(@"onConsentInfoUpdateSuccess FROM NOT AVAILABLE");
                     }
-                    
-                    _LoadForm( false, true );
                 }
+                _LoadForm( false, true );
             }];
     }
 }


### PR DESCRIPTION
Hello, thank you for this fantastic tool.
When errors came from Admob, like form misconfiguration, etc., the plugin only put an error log. 
With these changes, it will respond with no form available to help other codes that are dependent on this response start to work.